### PR TITLE
chore: Add commit linter

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,17 @@
+name: Check PR
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint commits
+        uses: wagoid/commitlint-github-action@v2.0.3

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.4.1
 


### PR DESCRIPTION
Add a commit linter when raising a PR, it will ensure that the commits
conform to the correct format so that automated releases work as
expected.

NO-TICKET